### PR TITLE
feat(RHTAP-2077): Create the create-frontend-dockerfile Tekton task

### DIFF
--- a/.tekton/consoledot-frontend-build-tests-pull-request.yaml
+++ b/.tekton/consoledot-frontend-build-tests-pull-request.yaml
@@ -208,25 +208,6 @@ spec:
       workspaces:
       - name: source
         workspace: workspace
-    - name: inject-dockerfile
-      params:
-        - name: path-context
-          value: $(params.path-context)
-      taskRef:
-        resolver: git
-        params:
-          - name: url
-            value: '{{source_url}}'
-          - name: revision
-            value: '{{source_branch}}'
-          - name: pathInRepo
-            value: tasks/inject-dockerfile/inject-dockerfile.yaml
-      workspaces:
-      - name: dockerfilews
-        workspace: workspace
-      runAfter:
-      - clone-repository
-      - parse-build-deploy-script
     - name: parse-build-deploy-script
       params:
         - name: path-context
@@ -245,6 +226,50 @@ spec:
         workspace: workspace
       runAfter:
       - clone-repository
+    - name: create-frontend-dockerfile
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: '{{source_url}}'
+          - name: revision
+            value: '{{source_branch}}'
+          - name: pathInRepo
+            value: tasks/create-frontend-dockerfile/create-frontend-dockerfile.yaml
+      workspaces:
+      - name: source
+        workspace: workspace
+      params:
+        - name: path-context
+          value: $(params.path-context)
+        - name: component
+          value: $(tasks.parse-build-deploy-script.results.component)
+        - name: image
+          value: $(tasks.parse-build-deploy-script.results.image)
+        - name: node-build-version
+          value: $(tasks.parse-build-deploy-script.results.node-build-version)
+        - name: quay-expire-time
+          value: $(tasks.parse-build-deploy-script.results.quay-expire-time)
+        - name: npm-build-script
+          value: $(tasks.parse-build-deploy-script.results.npm-build-script)
+        - name: yarn-build-script
+          value: $(tasks.parse-build-deploy-script.results.yarn-build-script)
+        - name: route-path
+          value: $(tasks.parse-build-deploy-script.results.route-path)
+        - name: beta-route-path
+          value: $(tasks.parse-build-deploy-script.results.beta-route-path)
+        - name: preview-route-path
+          value: $(tasks.parse-build-deploy-script.results.preview-route-path)
+        - name: is-pr
+          value: "true"
+        - name: ci-root
+          value: $(tasks.parse-build-deploy-script.results.ci-root)
+        - name: server-name
+          value: $(tasks.parse-build-deploy-script.results.server-name)
+        - name: dist-folder
+          value: $(tasks.parse-build-deploy-script.results.dist-folder)
+      runAfter:
+      - parse-build-deploy-script
     - name: build-container
       params:
       - name: IMAGE
@@ -263,7 +288,7 @@ spec:
         value: $(tasks.clone-repository.results.commit)
       runAfter:
       - prefetch-dependencies
-      - inject-dockerfile
+      - create-frontend-dockerfile
       taskRef:
         params:
         - name: name

--- a/.tekton/consoledot-frontend-build-tests-push.yaml
+++ b/.tekton/consoledot-frontend-build-tests-push.yaml
@@ -204,23 +204,10 @@ spec:
       workspaces:
       - name: source
         workspace: workspace
-    - name: inject-dockerfile
-      taskRef:
-        resolver: git
-        params:
-          - name: url
-            value: '{{source_url}}'
-          - name: revision
-            value: '{{source_branch}}'
-          - name: pathInRepo
-            value: tasks/inject-dockerfile/inject-dockerfile.yaml
-      workspaces:
-      - name: dockerfilews
-        workspace: workspace
-      runAfter:
-      - clone-repository
-      - parse-build-deploy-script
     - name: parse-build-deploy-script
+      params:
+        - name: path-context
+          value: $(params.path-context)
       taskRef:
         resolver: git
         params:
@@ -235,6 +222,50 @@ spec:
         workspace: workspace
       runAfter:
       - clone-repository
+    - name: create-frontend-dockerfile
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: '{{source_url}}'
+          - name: revision
+            value: '{{source_branch}}'
+          - name: pathInRepo
+            value: tasks/create-frontend-dockerfile/create-frontend-dockerfile.yaml
+      workspaces:
+      - name: source
+        workspace: workspace
+      params:
+        - name: path-context
+          value: $(params.path-context)
+        - name: component
+          value: $(tasks.parse-build-deploy-script.results.component)
+        - name: image
+          value: $(tasks.parse-build-deploy-script.results.image)
+        - name: node-build-version
+          value: $(tasks.parse-build-deploy-script.results.node-build-version)
+        - name: quay-expire-time
+          value: $(tasks.parse-build-deploy-script.results.quay-expire-time)
+        - name: npm-build-script
+          value: $(tasks.parse-build-deploy-script.results.npm-build-script)
+        - name: yarn-build-script
+          value: $(tasks.parse-build-deploy-script.results.yarn-build-script)
+        - name: route-path
+          value: $(tasks.parse-build-deploy-script.results.route-path)
+        - name: beta-route-path
+          value: $(tasks.parse-build-deploy-script.results.beta-route-path)
+        - name: preview-route-path
+          value: $(tasks.parse-build-deploy-script.results.preview-route-path)
+        - name: is-pr
+          value: "false"
+        - name: ci-root
+          value: $(tasks.parse-build-deploy-script.results.ci-root)
+        - name: server-name
+          value: $(tasks.parse-build-deploy-script.results.server-name)
+        - name: dist-folder
+          value: $(tasks.parse-build-deploy-script.results.dist-folder)
+      runAfter:
+      - parse-build-deploy-script
     - name: build-container
       params:
       - name: IMAGE
@@ -253,7 +284,7 @@ spec:
         value: $(tasks.clone-repository.results.commit)
       runAfter:
       - prefetch-dependencies
-      - inject-dockerfile
+      - create-frontend-dockerfile
       taskRef:
         params:
         - name: name

--- a/tasks/create-frontend-dockerfile/README.md
+++ b/tasks/create-frontend-dockerfile/README.md
@@ -1,0 +1,22 @@
+# create-frontend-dockerfile
+
+Tekton task that uses the frontend builder container to create a Dockerfile to build a Consoledot Frontend application.
+
+## Parameters
+
+| Name               | Description                                                       | Optional | Default value |
+|--------------------|-------------------------------------------------------------------|----------|---------------|
+| subdirectory       | directory in the `output` Workspace to clone the repo into        | Yes      | source        |
+| path-context       | path context directory inside the repo                            | No       | -             |
+| component          | name of app-sre application folder this component lives in        | No       | -             |
+| image              | image should match the quay repo set by app.yaml in app-interface | No       | -             |
+| quay-expire-time   | time for the image to expire in Quay. Default is 3 days           | Yes      | 3d            |
+| npm-build-script   | npm script to run at build time                                   | Yes      | build         |
+| yarn-build-script  | yarn script to run at build time                                  | Yes      | build:prod    |
+| route-path         | path for the app to be stored                                     | Yes      | ""            |
+| beta-route-path    | path for the beta app to be stored                                | Yes      | ""            |
+| preview-route-path | path for the preview app to be stored                             | Yes      | ""            |
+| is-pr              | true if it comes from a PR                                        | Yes      | "true"        |
+| ci-root            | root of the ci.sh script                                          | Yes      | ""            |
+| server-name        | name of the server. If empty, same as the app name                | Yes      | ""            |
+| dist-folder        | directory where the app.info.json will be written                 | Yes      | ""            |

--- a/tasks/create-frontend-dockerfile/create-frontend-dockerfile.yaml
+++ b/tasks/create-frontend-dockerfile/create-frontend-dockerfile.yaml
@@ -1,0 +1,113 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: create-frontend-dockerfile
+spec:
+  description: >-
+    Tekton task to create a dockerfile for the frontend builds
+  params:
+    - default: "source"
+      description: directory in the `output` Workspace to clone the repo into.
+      name: subdirectory
+      type: string
+    - name: path-context
+      description: path context directory inside the repo
+      type: string
+    - name: component
+      description: name of app-sre application folder this component lives in
+      type: string
+    - name: image
+      description: |
+        image should match the quay repo set by app.yaml in app-interface
+      type: string
+    - name: node-build-version
+      description: node version to build the app
+      type: string
+      default: 16
+    - name: quay-expire-time
+      description: time for the image to expire in Quay. Default is 3 days
+      type: string
+      default: 3d
+    - name: npm-build-script
+      type: string
+      description: npm script to run at build time
+      default: build
+    - name: yarn-build-script
+      type: string
+      description: yarn script to run at build time
+      default: build:prod
+    - name: route-path
+      type: string
+      description: path for the app to be stored
+      default: ""
+    - name: beta-route-path
+      type: string
+      description: path for the beta app to be stored
+      default: ""
+    - name: preview-route-path
+      type: string
+      description: path for the preview app to be stored
+      default: ""
+    - name: is-pr
+      type: string
+      description: true if it comes from a PR
+      default: "true"
+    - name: ci-root
+      type: string
+      description: root of the ci.sh script
+      default: ""
+    - name: server-name
+      type: string
+      description: name of the server. If empty, same as the app name
+      default: ""
+    - name: dist-folder
+      type: string
+      description: directory where the app.info.json will be written
+      default: ""
+  workspaces:
+    - name: source
+      description: workspace where the code is stored
+  steps:
+    - name: create-dockerfile
+      image: quay.io/cloudservices/frontend-build-container:latest
+      script: |
+        #!/usr/bin/env sh
+        set -xe
+
+        source_path=$(workspaces.source.path)/$(params.subdirectory)/$(params.path-context)
+
+        cp -r  $source_path/. /workspace
+        ls -a /workspace
+        sh /container_workspace/universal_build.sh
+
+        cp /container_workspace/Dockerfile $source_path
+        cp /container_workspace/Caddyfile $source_path
+        cp -r /container_workspace/dist $source_path
+      env:
+        - name: COMPONENT
+          value: $(params.component)
+        - name: IMAGE
+          value: $(params.image)
+        - name: NODE_BUILD_VERSION
+          value: $(params.node-build-version)
+        - name: QUAY_EXPIRE_TIME
+          value: $(params.quay-expire-time)
+        - name: NPM_BUILD_SCRIPT
+          value: $(params.npm-build-script)
+        - name: YARN_BUILD_SCRIPT
+          value: $(params.yarn-build-script)
+        - name: ROUTE_PATH
+          value: $(params.route-path)
+        - name: BETA_ROUTE_PATH
+          value: $(params.beta-route-path)
+        - name: PREVIEW_ROUTE_PATH
+          value: $(params.preview-route-path)
+        - name: IS_PR
+          value: $(params.is-pr)
+        - name: CI_ROOT
+          value: $(params.ci-root)
+        - name: SERVER_NAME
+          value: $(params.server-name)
+        - name: DIST_FOLDER
+          value: $(params.dist-folder)

--- a/tasks/parse-build-deploy-script/parse-build-deploy-script.yaml
+++ b/tasks/parse-build-deploy-script/parse-build-deploy-script.yaml
@@ -14,7 +14,7 @@ spec:
       name: subdirectory
       type: string
     - name: path-context
-      default: tests/insights-dashboard-master
+      default: ""
       description: path context directory inside the repo
       type: string
   results:
@@ -30,18 +30,75 @@ spec:
     - name: quay-expire-time
       type: string
       description: variable for quay's expiry time
+    - name: npm-build-script
+      type: string
+      description: npm script to run at build time
+    - name: yarn-build-script
+      type: string
+      description: yarn script to run at build time
+    - name: route-path
+      type: string
+      description: path for the app to be stored
+    - name: beta-route-path
+      type: string
+      description: path for the beta app to be stored
+    - name: preview-route-path
+      type: string
+      description: path for the preview app to be stored
+    - name: ci-root
+      type: string
+      description: root of the ci.sh script
+    - name: server-name
+      type: string
+      description: name of the server. If empty, same as the app name
+    - name: dist-folder
+      type: string
+      description: directory where the app.info.json will be written
   steps:
     - name: parse-build-deploy-script
       image: registry.access.redhat.com/ubi9/ubi-minimal:9.3-1361.1699548032
       script: |
-        #!/usr/bin/env sh
+        #!/bin/bash
         set -ex
-        script_path=$(workspaces.source.path)/$(params.subdirectory)/$(params.path-context)/build_deploy.sh
-        component=$(grep 'COMPONENT=' $script_path | awk -F= '{print $2}')
-        echo "$component" | tee "$(results.component.path)"
-        image=$(grep 'IMAGE=' $script_path | awk -F= '{print $2}')
-        echo "$image" | tee "$(results.image.path)"
-        node_version=$(grep 'NODE_BUILD_VERSION=' $script_path | awk -F= '{print $2}')
-        echo "$node_version" | tee "$(results.node-build-version.path)"
-        quay_expire_time=$(grep 'QUAY_EXPIRE_TIME=' $script_path | awk -F= '{print $2}')
-        echo "$quay_expire_time" | tee "$(results.quay-expire-time.path)"
+
+        # function to convert variables from kebab-case to SCREAM_SNAKE_CASE
+        function convert_var_name() {
+          echo "$1" | tr '-' '_' | tr '[:lower:]' '[:upper:]'
+        }
+
+        cd $(workspaces.source.path)/$(params.subdirectory)\
+        /$(params.path-context)
+
+        script_path=build_deploy.sh
+
+        results="component image node-build-version quay-expire-time
+        npm-build-script yarn-build-script route-path beta-route-path
+        preview-route-path ci-root server-name dist-folder"
+
+        for result in $results
+        do
+          RESULT=$(convert_var_name "$result")
+          result_value="$(grep "$RESULT=" $script_path | awk -F= '{print $2}')"
+          echo -n "$result_value" | tee /workspace/$result
+        done
+
+        # I can't write to results from a for using a variable
+        cat /workspace/component | tee $(results.component.path)
+        cat /workspace/image | tee $(results.image.path)
+        cat /workspace/ci-root | tee $(results.ci-root.path)
+        cat /workspace/server-name | tee $(results.server-name.path)
+        cat /workspace/dist-folder | tee $(results.dist-folder.path)
+        cat /workspace/node-build-version \
+        | tee $(results.node-build-version.path)
+        cat /workspace/quay-expire-time \
+        | tee $(results.quay-expire-time.path)
+        cat /workspace/npm-build-script \
+        | tee $(results.npm-build-script.path)
+        cat /workspace/yarn-build-script \
+        | tee $(results.yarn-build-script.path)
+        cat /workspace/route-path \
+        | tee $(results.route-path.path)
+        cat /workspace/beta-route-path \
+        | tee $(results.beta-route-path.path)
+        cat /workspace/preview-route-path \
+        | tee $(results.preview-route-path.path)

--- a/tests/scripts/.tasks
+++ b/tests/scripts/.tasks
@@ -1,10 +1,10 @@
 # No need to test
-no_test_tasks=""
+no_test_tasks="inject-dockerfile"
 
 # Tasks that need to be tested in the PR pipeline,
 # names are separated by a space
-pr_tasks="inject-dockerfile parse-build-deploy-script"
+pr_tasks="parse-build-deploy-script create-frontend-dockerfile"
 
 # Tasks that need to be tested in the push pipeline
 # names are separated by a space
-push_tasks="inject-dockerfile parse-build-deploy-script"
+push_tasks="parse-build-deploy-script"


### PR DESCRIPTION
- Create the create-frontend-dockerfile task calling the frontend-build-container
- Update all the environment variables needed from build_deploy.sh in the parse-build-deploy-script task
- Change to a for loop the way to handle variables in the parse-build-deploy-script task
- Stop using inject-dockerfile task since it was a POC
- Add new task to the Tekton files