### PR TITLE
fix: remove is-pr as parameter and set env var to false

### DIFF
--- a/.tekton/consoledot-frontend-build-tests-pull-request.yaml
+++ b/.tekton/consoledot-frontend-build-tests-pull-request.yaml
@@ -257,8 +257,6 @@ spec:
           value: $(tasks.parse-build-deploy-script.results.beta-route-path)
         - name: preview-route-path
           value: $(tasks.parse-build-deploy-script.results.preview-route-path)
-        - name: is-pr
-          value: "true"
         - name: ci-root
           value: $(tasks.parse-build-deploy-script.results.ci-root)
         - name: server-name

--- a/.tekton/consoledot-frontend-build-tests-push.yaml
+++ b/.tekton/consoledot-frontend-build-tests-push.yaml
@@ -253,8 +253,6 @@ spec:
           value: $(tasks.parse-build-deploy-script.results.beta-route-path)
         - name: preview-route-path
           value: $(tasks.parse-build-deploy-script.results.preview-route-path)
-        - name: is-pr
-          value: "false"
         - name: ci-root
           value: $(tasks.parse-build-deploy-script.results.ci-root)
         - name: server-name

--- a/tasks/create-frontend-dockerfile/README.md
+++ b/tasks/create-frontend-dockerfile/README.md
@@ -16,7 +16,6 @@ Tekton task that uses the frontend builder container to create a Dockerfile to b
 | route-path         | path for the app to be stored                                     | Yes      | ""            |
 | beta-route-path    | path for the beta app to be stored                                | Yes      | ""            |
 | preview-route-path | path for the preview app to be stored                             | Yes      | ""            |
-| is-pr              | true if it comes from a PR                                        | Yes      | "true"        |
 | ci-root            | root of the ci.sh script                                          | Yes      | ""            |
 | server-name        | name of the server. If empty, same as the app name                | Yes      | ""            |
 | dist-folder        | directory where the app.info.json will be written                 | Yes      | ""            |

--- a/tasks/create-frontend-dockerfile/create-frontend-dockerfile.yaml
+++ b/tasks/create-frontend-dockerfile/create-frontend-dockerfile.yaml
@@ -49,10 +49,6 @@ spec:
       type: string
       description: path for the preview app to be stored
       default: ""
-    - name: is-pr
-      type: string
-      description: true if it comes from a PR
-      default: "true"
     - name: ci-root
       type: string
       description: root of the ci.sh script
@@ -109,7 +105,7 @@ spec:
         - name: PREVIEW_ROUTE_PATH
           value: $(params.preview-route-path)
         - name: IS_PR
-          value: $(params.is-pr)
+          value: "false"
         - name: CI_ROOT
           value: $(params.ci-root)
         - name: SERVER_NAME


### PR DESCRIPTION
- Removed the is-pr parameter from the create-frontend-dockerfile task
- Set the IS_PR environment variable to false, since that was currently creating not reproducible builds